### PR TITLE
Fix: Resolve 404 error for missing vite.svg

### DIFF
--- a/public/vite.svg
+++ b/public/vite.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-zap"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"></polygon></svg>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,6 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
-  base: './',
   plugins: [react()],
   test: {
     globals: true,


### PR DESCRIPTION
This commit resolves a 404 error that occurred after the application was published. The error was caused by a reference to a missing `vite.svg` file in `index.html`.

The following changes were made:
- A `public` directory was created to store static assets.
- A placeholder `vite.svg` file was added to the `public` directory.
- The `base: './'` property was removed from `vite.config.ts` to ensure that asset paths are resolved correctly.